### PR TITLE
adds helpers crate which exposes commit_if_not_in_chain and uses that

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdk-helpers"
+version = "0.1.0"
+dependencies = [
+ "hdk 0.0.40-alpha1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +509,7 @@ name = "hylo_comments"
 version = "0.0.3"
 dependencies = [
  "hdk 0.0.40-alpha1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hdk-helpers 0.1.0",
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -513,6 +521,7 @@ name = "hylo_communities"
 version = "0.0.3"
 dependencies = [
  "hdk 0.0.40-alpha1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hdk-helpers 0.1.0",
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -538,6 +547,7 @@ dependencies = [
  "derive_more 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hdk 0.0.40-alpha1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hdk-helpers 0.1.0",
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,6 @@ members = [
   "zomes/messages/code",
   "zomes/people/code",
   "zomes/posts/code",
+
+  "common/hdk-helpers",
 ]

--- a/common/hdk-helpers/Cargo.toml
+++ b/common/hdk-helpers/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "hdk-helpers"
+version = "0.1.0"
+authors = ["Willem Olding <willemolding@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+hdk = "0.0.40-alpha1"

--- a/common/hdk-helpers/src/lib.rs
+++ b/common/hdk-helpers/src/lib.rs
@@ -1,0 +1,14 @@
+
+use hdk::prelude::*;
+
+pub fn commit_if_not_in_chain(entry: &Entry) -> ZomeApiResult<Address> {
+	// use query to check the chain. When there is an HDK function doing this directly use it instead
+	let existing_entries = hdk::query(entry.entry_type().into(), 0, 0)?;
+	if existing_entries.contains(&entry.address()) {
+		// do nothing and be happy
+		Ok(entry.address())
+	} else {
+		// do the commit as usual
+		hdk::commit_entry(entry)
+	}
+}

--- a/zomes/comments/code/Cargo.toml
+++ b/zomes/comments/code/Cargo.toml
@@ -10,6 +10,7 @@ serde_json = { version = "=1.0.39", features = ["preserve_order"] }
 serde_derive = "=1.0.89"
 hdk = "0.0.40-alpha1"
 holochain_json_derive = "=0.0.17"
+hdk-helpers = { path="../../../common/hdk-helpers" }
 
 [lib]
 path = "src/lib.rs"

--- a/zomes/comments/code/src/comments/mod.rs
+++ b/zomes/comments/code/src/comments/mod.rs
@@ -23,6 +23,7 @@ use hdk::{
     },
     holochain_persistence_api::{cas::content::Address},
 };
+use hdk_helpers::commit_if_not_in_chain;
 
 // tag for links from base to comment
 
@@ -82,7 +83,7 @@ pub fn create(base: String, text: String, timestamp: Iso8601) -> ZomeApiResult<C
 
     // store an entry for the ID of the base object the comment was made on
     let base_entry = Entry::App(BASE_ENTRY_TYPE.into(), RawString::from(base.clone()).into());
-    let base_address = hdk::commit_entry(&base_entry)?;
+    let base_address = commit_if_not_in_chain(&base_entry)?;
 
     // link the comment to its originating thing
     hdk::link_entries(

--- a/zomes/communities/code/Cargo.toml
+++ b/zomes/communities/code/Cargo.toml
@@ -10,6 +10,7 @@ serde_json = { version = "=1.0.39", features = ["preserve_order"] }
 serde_derive = "=1.0.89"
 hdk = "0.0.40-alpha1"
 holochain_json_derive = "=0.0.17"
+hdk-helpers = { path="../../../common/hdk-helpers" }
 
 [lib]
 path = "src/lib.rs"

--- a/zomes/communities/code/src/communities/mod.rs
+++ b/zomes/communities/code/src/communities/mod.rs
@@ -16,6 +16,8 @@ use hdk::{
     holochain_persistence_api::{cas::content::{Address, AddressableContent}},
 
 };
+use hdk_helpers::commit_if_not_in_chain;
+
 use super::DEFAULT_COMMUNITIES;
 
 #[derive(Serialize, Deserialize, Debug, Clone, DefaultJson)]
@@ -86,7 +88,7 @@ pub fn get_by_slug(slug: String) -> ZomeApiResult<CommunityWithAddress> {
 pub fn create(name: String, slug: String) -> ZomeApiResult<CommunityWithAddress> {
 
     let base_entry = Entry::App(COMMUNITY_BASE_ENTRY.into(), RawString::from(COMMUNITY_BASE_ENTRY).into());
-    let base_address = hdk::commit_entry(&base_entry)?;
+    let base_address = commit_if_not_in_chain(&base_entry)?;
 
     let slug_entry = Entry::App(COMMUNITY_BASE_ENTRY.into(), RawString::from(slug.clone()).into());
     let slug_address = hdk::commit_entry(&slug_entry)?;

--- a/zomes/messages/code/src/lib.rs
+++ b/zomes/messages/code/src/lib.rs
@@ -19,6 +19,7 @@ use hdk::{
     },
     holochain_persistence_api::{cas::content::Address},
 };
+
 mod message;
 mod thread;
 

--- a/zomes/people/code/Cargo.toml
+++ b/zomes/people/code/Cargo.toml
@@ -13,6 +13,7 @@ log = "0.4.6"
 env_logger = "0.6.1"
 hdk = "0.0.40-alpha1"
 holochain_json_derive = "=0.0.17"
+hdk-helpers = { path="../../../common/hdk-helpers" }
 
 [lib]
 path = "src/lib.rs"

--- a/zomes/people/code/src/people/mod.rs
+++ b/zomes/people/code/src/people/mod.rs
@@ -19,8 +19,8 @@ use hdk::{
         json::{JsonString},
     },
     holochain_persistence_api::{cas::content::{Address,AddressableContent}},
-
 };
+use hdk_helpers::commit_if_not_in_chain;
 
 pub const PERSON_ENTRY_TYPE: &str = "person";
 pub const PERSON_AGENT_LINK_TYPE:&str = "person_to_agent_link";
@@ -92,7 +92,7 @@ pub fn register_user(name: String, avatar_url: String) -> ZomeApiResult<PersonWi
         }
         .into(),
     );
-    let anchor_addr = hdk::commit_entry(&anchor_entry)?;
+    let anchor_addr = commit_if_not_in_chain(&anchor_entry)?;
     hdk::link_entries(&anchor_addr, &AGENT_ADDRESS, ANCHOR_PERSON_LINK_TYPE, "")?;
 
     Ok(person.with_address(AGENT_ADDRESS.to_string().into()))


### PR DESCRIPTION
Due to an incorrect assumption a duplicate chain header (and published header entry) was added when the base anchors for communities/people etc were added.

This adds a check that the entry isn't already in the local chain. So now at least there will be only one duplicate per agent.